### PR TITLE
Updating python-json-logger to 2.0.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-python-json-logger = "^0.1.11"
+python-json-logger = "^2.0.4"
 strenum = "^0.4.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
### What

Update python-json-logger dependency to 2.0.x

### Why

I am trying to add an SDK to GRID-api which has very few dependencies (three in fact) and one of them is python-json-logger (>=2.0.4,<2.1.0).

I figured I could try and roll an RC and push to PyPI so I can get this other SDK working, at least for a proof of concept.

### How

I would have preferred to update to the latest version of the library, but that's version 3.0 already.
